### PR TITLE
Add support for miniupnpc API 14

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1020,10 +1020,14 @@ void ThreadMapPort()
 #ifndef UPNPDISCOVER_SUCCESS
     /* miniupnpc 1.5 */
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0);
-#else
+#elif MINIUPNPC_API_VERSION < 14
     /* miniupnpc 1.6 */
     int error = 0;
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
+#else
+    /* miniupnpc 1.9.20150730 */
+    int error = 0;
+    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, 2, &error);
 #endif
 
     struct UPNPUrls urls;


### PR DESCRIPTION
ported from https://github.com/bitcoin/bitcoin/pull/6583/files

Fixes this error

net.cpp:1026:68: error: invalid conversion from ‘int*’ to ‘unsigned char’ [
-fpermissive]
    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);                                                                   ^~~~~~  
net.cpp:1026:74: error: too few arguments to function ‘UPNPDev* upnpDiscove
r(int, const char*, const char*, int, int, unsigned char, int*)’
    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
            